### PR TITLE
adding field axis opts + detrending for the vsd

### DIFF
--- a/view/helpers.py
+++ b/view/helpers.py
@@ -3,6 +3,8 @@ import numpy as np
 import streamlit as st
 from simulation_fns import get_pimm_data, get_vsd_data
 
+from cmtj.utils import Filters
+
 
 def read_data():
     filedata = st.session_state.upload.read().decode("utf-8")
@@ -104,8 +106,9 @@ def simulate_vsd():
             fstep=st.session_state.fstep * 1e9,
             Rtype=st.session_state.res_type,
             sim_time=st.session_state.sim_time * 1e-9,
-            Hoex_mag=st.session_state.Hoex_mag * 1e3,
+            Hoex_mag=st.session_state.Hoex_mag,
         )
+        spec = Filters.detrend_axis(spec, axis=0)
     plot_data(Hscan, freqs, spec, title="VSD spectrum")
 
 

--- a/view/simulation_fns.py
+++ b/view/simulation_fns.py
@@ -48,6 +48,12 @@ def get_axis_cvector(axis: str):
         return CVector(0, 1, 0)
     elif axis == "z":
         return CVector(0, 0, 1)
+    elif axis == 'xy':
+        return CVector(1, 1, 0)
+    elif axis == 'xz':
+        return CVector(1, 0, 1)
+    elif axis == 'yz':
+        return CVector(0, 1, 1)
     else:
         raise ValueError(f"Invalid axis {axis}")
 
@@ -71,6 +77,12 @@ def get_axis_angles(axis: str):
         return 90, 90
     elif axis == "z":
         return 0, 0
+    elif axis == 'xy':
+        return 90, 45
+    elif axis == 'xz':
+        return 45, 0
+    elif axis == 'yz':
+        return 45, 90
     else:
         raise ValueError(f"Invalid axis {axis}")
 

--- a/view/streamlit_app.py
+++ b/view/streamlit_app.py
@@ -102,7 +102,9 @@ with st.sidebar:
     st.markdown("-----\n")
     st.markdown("## Control parameters")
     st.markdown("### External field")
-    st.selectbox("H axis", options=["x", "y", "z"], key="H_axis", index=0)
+    st.selectbox(
+        "H axis", options=["x", "y", "z", "xy", "xz", "yz"], key="H_axis", index=0
+    )
     st.number_input(
         "Hmin (kA/m)", min_value=-1000.0, max_value=1000.0, value=-400.0, key="Hmin"
     )
@@ -227,7 +229,7 @@ with vsd_tab:
         step=0.1,
     )
     st.number_input(
-        "Excitation (kA/m)", min_value=0.5, max_value=50.0, value=5.0, key="Hoex_mag"
+        "Excitation (A/m)", min_value=1e-5, max_value=1e5, value=500.0, key="Hoex_mag"
     )
     st.selectbox(
         "Resistance type",


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request introduces new axis options ('xy', 'xz', 'yz') for external field selection, updates the excitation input range for better precision, and adds detrending functionality for the VSD spectrum.

- **New Features**:
    - Added support for new axis options ('xy', 'xz', 'yz') in the external field selection.
- **Enhancements**:
    - Updated the excitation input range in the Streamlit app from kA/m to A/m for better precision.
    - Integrated detrending functionality for the VSD spectrum using the Filters utility.

<!-- Generated by sourcery-ai[bot]: end summary -->