### PR TITLE
workflow fix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
         if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
         run: |
           python -m pip install --upgrade pip 
-          python -m pip install wheel setuptools twine
+          python -m pip install wheel setuptools twine packaging>=24.2
           twine upload dist/*-manylinux*.whl
         continue-on-error: false
     
@@ -62,7 +62,7 @@ jobs:
       - name: build wheel
         run: |
           python -m pip install --upgrade pip 
-          python -m pip install wheel setuptools twine
+          python -m pip install wheel setuptools twine packaging>=24.2
           python setup.py bdist_wheel
       - name: upload wheel
         if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Add `packaging>=24.2` to the list of dependencies installed in the CI workflow before building and uploading wheels. This ensures that the latest version of the `packaging` library is used, which fixes an issue with uploading wheels to PyPI when using older versions of the library that are incompatible with the latest PyPI version. The change affects both the `build-and-upload-wheels` and `build-linux-wheels` jobs in the workflow, ensuring consistent dependency management across different build environments.