### PR TITLE
Fix/import fixes

### DIFF
--- a/docker/Dockerfile.wheel
+++ b/docker/Dockerfile.wheel
@@ -15,7 +15,7 @@ COPY third_party /scratch/third_party
 COPY cmtj /scratch/cmtj
 
 RUN python3 -m setup bdist_wheel && \
-    python3 -m pip install dist/*.whl numpy scipy tqdm
+    python3 -m pip install dist/*.whl numpy==1.26.4 scipy==1.13.1 tqdm==4.67.1 sympy==1.12
 
 WORKDIR /app
 RUN python3 -c "import cmtj; from cmtj.utils import FieldScan" && \

--- a/python/cmtj.cpp
+++ b/python/cmtj.cpp
@@ -118,8 +118,8 @@ PYBIND11_MODULE(cmtj, m) {
           .def("__getitem__",
                [](const DVector& v, const int key) { return v[key]; })
           .def("__len__", [](const DVector& v) { return 3; })
-          .def("__str__", [](const DVector& v) { return v.toString(); })
-          .def("__repr__", [](const DVector& v) { return v.toString(); })
+          .def("__str__", py::overload_cast<>(&DVector::toString))
+          .def("__repr__", py::overload_cast<>(&DVector::toString))
           .def_static("fromSpherical", &DVector::fromSpherical, "theta"_a, "phi"_a, "r"_a = 1.0);
 
      py::implicitly_convertible<std::list<double>, DVector>();

--- a/setup.py
+++ b/setup.py
@@ -151,7 +151,7 @@ setup(
             *find_stubs(path=Path("cmtj")),
         ]
     },
-    setup_requires=["pybind11>=2.6.1"],
+    setup_requires=["pybind11>=2.6.1,<3.0.0"],
     cmdclass={"build_ext": BuildExt},
     zip_safe=False,
 )


### PR DESCRIPTION
## Summary by Sourcery

Simplify DVector Python bindings by replacing lambdas with py::overload_cast and restrict the pybind11 setup dependency to versions below 3.0.0.

Enhancements:
- Replace custom lambda wrappers for DVector::toString with py::overload_cast bindings for __str__ and __repr__.

Build:
- Pin setup_requires pybind11 dependency to >=2.6.1 and <3.0.0.