### PR TITLE
Reworking optional synchronisation option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+# 1.8.0
+
+- Fixing bugs in electrical coupling
+- You can now have useKCL = True Stacks which will implicitly preserve Kirchoff's current law, and will simulate perfect voltage sources
+
+# 1.7.0
+
+- Adaptive simulation is now available again with Dormand-Price method
+- Adding curated simulation examples
+- Memory cells are now supported (you can specify two polarisation vectors per Layer now)
+- Import fixes and other minor bugfixes
+
 # 1.6.2-1.6.6
 
 - Fixed a bug in the `ScalarDriver` class which prevented the use of custom drivers with no arguments.

--- a/cmtj/stack/__init__.pyi
+++ b/cmtj/stack/__init__.pyi
@@ -9,6 +9,7 @@ class ParallelStack:
         topId: str = "free",
         bottomId: str = "bottom",
         phaseOffset: float = 0,
+        useKCL: bool = True,
     ) -> None:
         """
         Initialises a parallel connection of junctions.
@@ -104,6 +105,7 @@ class SeriesStack:
         topId: str = "free",
         bottomId: str = "bottom",
         phaseOffset: float = 0,
+        useKCL: bool = True,
     ) -> None:
         """
         Initialises a series connection of junctions.

--- a/core/reservoir.hpp
+++ b/core/reservoir.hpp
@@ -32,12 +32,6 @@ void comb(int N, int K) {
 
 typedef std::array<CVector<double>, 3> tensor;
 typedef std::vector<tensor> tensorList;
-template <typename T>
-using solverFn = bool (Layer<T>::*)(T t, T &timeStep, const CVector<T> &bottom,
-                                    const CVector<T> &top);
-template <typename T>
-using runnerFn = void (Junction<T>::*)(solverFn<T> &functor, T &t, T &timeStep,
-                                       bool &step_accepted);
 
 const tensor getDipoleTensorFromRelPositions(const CVector<double> &r1,
                                              const CVector<double> &r2) {
@@ -134,7 +128,7 @@ class GroupInteraction {
 
   void stepFunctionalSolver(double time, double &timeStep,
                             interactionFunction interaction,
-                            runnerFn<double> runner, solverFn<double> solver,
+                            RunnerFn<double> runner, SolverFn<double> solver,
                             bool &step_accepted) {
     // collect all frozen states
     // for each element, compute the extra field from all other elements

--- a/core/stack.hpp
+++ b/core/stack.hpp
@@ -179,7 +179,10 @@ public:
     this->stackLog["Resistance"].push_back(resistance);
     for (std::size_t j = 0; j < timeCurrents.size(); ++j) {
       this->stackLog["I_" + std::to_string(j)].push_back(timeCurrents[j]);
-      this->stackLog["C_" + std::to_string(j)].push_back(effectiveCoupling[j]);
+      if (j < effectiveCoupling.size()) {
+        this->stackLog["C_" + std::to_string(j) + "_" + std::to_string(j + 1)]
+            .push_back(effectiveCoupling[j]);
+      }
     }
     this->stackLog["time"].push_back(t);
   }
@@ -264,7 +267,7 @@ private:
 
     std::vector<T> timeResistances(junctionList.size());
     std::vector<T> timeCurrents(junctionList.size());
-    std::vector<T> timeEffectiveCoupling(junctionList.size());
+    std::vector<T> timeEffectiveCoupling(junctionList.size() - 1);
     std::vector<CVector<T>> frozenMags(junctionList.size());
     std::vector<CVector<T>> frozenPols(junctionList.size());
 
@@ -312,8 +315,8 @@ private:
                      junctionList[j - 1].getLayerMagnetisation(this->bottomId),
                      junctionList[j].getLayerMagnetisation(this->bottomId)));
           }
+          timeEffectiveCoupling[j - 1] = effectiveCoupling;
         }
-        timeEffectiveCoupling[j] = effectiveCoupling;
         // set the current -- same for all layers
         // copy the driver and set the current value
         ScalarDriver<T> localDriver = this->currentDriver * effectiveCoupling;
@@ -369,7 +372,7 @@ private:
 
     std::vector<T> timeResistances(junctionList.size());
     std::vector<T> timeCurrents(junctionList.size());
-    std::vector<T> timeEffectiveCoupling(junctionList.size());
+    std::vector<T> timeEffectiveCoupling(junctionList.size() - 1);
     std::vector<CVector<T>> frozenMags(junctionList.size());
     std::vector<CVector<T>> frozenPols(junctionList.size());
     const bool isTwoLayerStack = this->isTwoLayerMemberStack();

--- a/python/cmtj.cpp
+++ b/python/cmtj.cpp
@@ -358,9 +358,9 @@ PYBIND11_MODULE(cmtj, m) {
           m.def_submodule("stack", "A stack submodule for joining MTJ junctions");
 
      py::class_<DSeriesStack>(stack_module, "SeriesStack")
-          .def(py::init<std::vector<DJunction>, std::string, std::string, double>(),
+          .def(py::init<std::vector<DJunction>, std::string, std::string, double, bool>(),
                "junctionList"_a, "topId_a"_a = "free", "bottomId"_a = "bottom",
-               "phaseOffset"_a = 0.0)
+               "phaseOffset"_a = 0.0, "useKCL"_a = true)
           .def("runSimulation", &DSeriesStack::runSimulation, "totalTime"_a,
                "timeStep"_a = 1e-13, "writeFrequency"_a = 1e-11)
           .def("setMagnetisation", &DSeriesStack::setMagnetisation, "junction"_a,
@@ -391,9 +391,9 @@ PYBIND11_MODULE(cmtj, m) {
           .def("getLog", py::overload_cast<>(&DSeriesStack::getLog));
 
      py::class_<DParallelStack>(stack_module, "ParallelStack")
-          .def(py::init<std::vector<DJunction>, std::string, std::string, double>(),
+          .def(py::init<std::vector<DJunction>, std::string, std::string, double, bool>(),
                "junctionList"_a, "topId_a"_a = "free", "bottomId"_a = "bottom",
-               "phaseOffset"_a = 0.0)
+               "phaseOffset"_a = 0.0, "useKCL"_a = true)
           .def("runSimulation", &DParallelStack::runSimulation, "totalTime"_a,
                "timeStep"_a = 1e-13, "writeFrequency"_a = 1e-11)
           .def("setMagnetisation", &DParallelStack::setMagnetisation, "junction"_a,
@@ -442,18 +442,6 @@ PYBIND11_MODULE(cmtj, m) {
                py::overload_cast<unsigned int>(&GroupInteraction::getLog))
           .def("getLog", py::overload_cast<unsigned int>(&GroupInteraction::getLog),
                py::return_value_policy::reference);
-
-     py::class_<Reservoir>(reservoir_module, "Reservoir")
-          .def(py::init<DVectorMatrix, DLayerMatrix>(), "coordinateMatrix"_a,
-               "layerMatrix"_a)
-          .def("runSimulation", &Reservoir::runSimulation)
-          .def("clearLogs", &Reservoir::clearLogs)
-          .def("saveLogs", &Reservoir::saveLogs)
-          .def("getLayer", &Reservoir::getLayer)
-          .def("setAllExternalField", &Reservoir::setAllExternalField)
-          .def("setLayerAnisotropy", &Reservoir::setLayerAnisotropy)
-          .def("setLayerExternalField", &Reservoir::setLayerExternalField)
-          .def("getMagnetisation", &Reservoir::getMagnetisation);
 
 
      // generator module

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import setuptools
 from setuptools import Extension, find_namespace_packages, setup
 from setuptools.command.build_ext import build_ext
 
-__version__ = "1.7.0"
+__version__ = "1.7.1"
 """
 As per
 https://github.com/pybind/python_example

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,8 @@ import setuptools
 from setuptools import Extension, find_namespace_packages, setup
 from setuptools.command.build_ext import build_ext
 
-__version__ = "1.7.1"
+__version__ = "1.8.0"
+
 """
 As per
 https://github.com/pybind/python_example

--- a/tests/test_sot_torques.py
+++ b/tests/test_sot_torques.py
@@ -1,0 +1,181 @@
+import pytest
+import cmtj
+
+
+def test_reference_layers():
+    """Test setting and getting reference layers"""
+
+    # Create a basic SOT layer
+    mag = cmtj.CVector(0, 0, 1)
+    anis = cmtj.CVector(0, 0, 1)
+    demag = [cmtj.CVector(0, 0, 0), cmtj.CVector(0, 0, 0), cmtj.CVector(0, 0, 1)]
+
+    layer = cmtj.Layer(
+        id="free",
+        mag=mag,
+        anis=anis,
+        Ms=1,
+        thickness=2e-9,
+        cellSurface=1e-18,
+        demagTensor=demag,
+        damping=0.01,
+    )
+
+    # Test setting reference layer magnetization
+    ref_mag = cmtj.CVector(1, 0, 0)
+    layer.setReferenceLayer(ref_mag)
+    assert layer.getReferenceLayer() == ref_mag
+
+    # Test setting secondary reference layer
+    sec_ref_mag = cmtj.CVector(0, 1, 0)
+    layer.setSecondaryReferenceLayer(sec_ref_mag)
+    assert layer.getSecondaryReferenceLayer() == sec_ref_mag
+
+
+def test_secondary_torques():
+    """Test setting secondary torque drivers"""
+
+    # Create a basic SOT layer
+    mag = cmtj.CVector(0, 0, 1)
+    anis = cmtj.CVector(0, 0, 1)
+    demag = [cmtj.CVector(0, 0, 0)] * 3
+
+    layer = cmtj.Layer(
+        id="free",
+        mag=mag,
+        anis=anis,
+        Ms=1,
+        thickness=2e-9,
+        cellSurface=1e-18,
+        demagTensor=demag,
+        damping=0.01,
+    )
+
+    # Create drivers
+    primary_fl_driver = cmtj.ScalarDriver.getConstantDriver(0.1)
+    primary_dl_driver = cmtj.ScalarDriver.getConstantDriver(0.2)
+    secondary_fl_driver = cmtj.ScalarDriver.getConstantDriver(0.3)
+    secondary_dl_driver = cmtj.ScalarDriver.getConstantDriver(0.4)
+
+    # Set primary and secondary torque drivers
+    layer.setPrimaryTorqueDrivers(primary_fl_driver, primary_dl_driver)
+    layer.setSecondaryTorqueDrivers(secondary_fl_driver, secondary_dl_driver)
+
+    # Set reference layers for torque effects
+    reference = cmtj.CVector(1, 0, 0)
+    secondary_reference = cmtj.CVector(0, 1, 0)
+    layer.setReferenceLayer(reference)
+    layer.setSecondaryReferenceLayer(secondary_reference)
+
+    # Create junction for simulation
+    junction = cmtj.Junction([layer])
+
+    # Run a short simulation to confirm there's no error
+    junction.runSimulation(1e-9, 1e-13, 1e-12)
+
+    # Logs should have been collected
+    log = junction.getLog()
+    assert "time" in log
+    assert "free_mx" in log
+    assert "free_my" in log
+    assert "free_mz" in log
+
+
+def test_junction_torque_drivers():
+    """Test setting torque drivers via junction interface"""
+
+    # Create two basic SOT layers
+    mag1 = cmtj.CVector(0, 0, 1)
+    mag2 = cmtj.CVector(1, 0, 0)
+    anis = cmtj.CVector(0, 0, 1)
+    demag = [cmtj.CVector(0, 0, 0)] * 3
+
+    layer1 = cmtj.Layer(
+        id="free1",
+        mag=mag1,
+        anis=anis,
+        Ms=1,
+        thickness=2e-9,
+        cellSurface=1e-18,
+        demagTensor=demag,
+        damping=0.01,
+    )
+
+    layer2 = cmtj.Layer(
+        id="free2",
+        mag=mag2,
+        anis=anis,
+        Ms=0.8,
+        thickness=1e-9,
+        cellSurface=1e-18,
+        demagTensor=demag,
+        damping=0.02,
+    )
+
+    # Create junction with both layers
+    junction = cmtj.Junction([layer1, layer2])
+
+    # Create drivers for both primary and secondary torques
+    fl_driver = cmtj.ScalarDriver.getConstantDriver(0.1)
+    dl_driver = cmtj.ScalarDriver.getConstantDriver(0.2)
+    sec_fl_driver = cmtj.ScalarDriver.getConstantDriver(0.3)
+    sec_dl_driver = cmtj.ScalarDriver.getConstantDriver(0.4)
+
+    # Set primary torque drivers via junction interface
+    junction.setLayerFieldLikeTorqueDriver("free1", fl_driver)
+    junction.setLayerDampingLikeTorqueDriver("free1", dl_driver)
+
+    # Set secondary torque drivers via junction interface
+    junction.setLayerSecondaryFieldLikeTorqueDriver("free1", sec_fl_driver)
+    junction.setLayerSecondaryDampingLikeTorqueDriver("free1", sec_dl_driver)
+
+    # Set combined torque drivers for the second layer
+    junction.setLayerPrimaryTorqueDrivers("free2", fl_driver, dl_driver)
+    junction.setLayerSecondaryTorqueDrivers("free2", sec_fl_driver, sec_dl_driver)
+
+    # Set reference layers
+    reference = cmtj.CVector(1, 0, 0)
+    junction.setLayerReferenceLayer("free1", reference)
+    junction.setLayerReferenceLayer("free2", reference)
+
+    # Set reference type for the second layer
+    junction.setLayerReferenceType("free2", cmtj.Reference.fixed)
+
+    # Run a short simulation to confirm there's no error
+    junction.runSimulation(1e-9, 1e-13, 1e-12)
+
+    # Logs should have been collected
+    log = junction.getLog()
+    assert "time" in log
+    assert "free1_mx" in log
+    assert "free1_my" in log
+    assert "free1_mz" in log
+    assert "free2_mx" in log
+    assert "free2_my" in log
+    assert "free2_mz" in log
+
+
+def test_must_raise_if_sot_driver_set_for_sot_layer():
+    """Test that an error is raised if a SOT driver is set for a SOT layer"""
+
+    layer = cmtj.Layer.createSOTLayer(
+        id="free",
+        mag=cmtj.CVector(0, 0, 1),
+        anis=cmtj.CVector(0, 0, 1),
+        Ms=1,
+        thickness=2e-9,
+        cellSurface=1e-18,
+        demagTensor=[cmtj.CVector(0, 0, 0)] * 3,
+        damping=0.01,
+    )
+
+    # Set a SOT driver
+    driver = cmtj.ScalarDriver.getConstantDriver(0.1)
+
+    # This should raise an error
+    with pytest.raises(RuntimeError):
+        layer.setFieldLikeTorqueDriver(driver)
+
+    # This should raise an error
+    with pytest.raises(RuntimeError):
+        layer.setDampingLikeTorqueDriver(driver)

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -1,4 +1,3 @@
-from regex import P
 from cmtj.stack import ParallelStack, SeriesStack
 from cmtj.utils.procedures import ResistanceParameters
 from cmtj import Layer, CVector, ScalarDriver
@@ -206,10 +205,8 @@ def test_kcl_vs_non_kcl_current_behavior(stack_type):
 
     mean_I0_non_kcl = np.mean(current_first_junction_non_kcl)
     mean_I0_kcl = np.mean(current_first_junction_kcl)
-    test_current = test_current / 1e12
-    print(mean_I0_non_kcl)
-    print(mean_I0_kcl)
-    print(test_current)
+    test_current /= 1e12
+
     # Verify that non-KCL preserves the input current in the first junction
     # (allowing for small numerical errors)
     assert np.allclose(


### PR DESCRIPTION
## Summary by Sourcery

Allow selecting between legacy and KCL-based stack simulation via a new useKCL option and refactor the runSimulation logic accordingly

New Features:
- Add optional KCL-based simulation method toggled by a useKCL constructor flag
- Expose the useKCL parameter in Python bindings for SeriesStack and ParallelStack

Enhancements:
- Refactor Stack::runSimulation into a delegator using a function pointer to switch between implementations
- Implement runSimulationKCL with solver mode consistency checks and coupling-based current computation

Chores:
- Remove unused Reservoir class bindings from the Python module