### PR TITLE
Fix build by disabling local setuptools_scm version tags

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ cmtj = ["py.typed", "**/*.pyi"]
 
 [tool.setuptools_scm]
 version_scheme = "no-guess-dev"
-local_scheme = "dirty-tag"
+local_scheme = "no-local-version"
 write_to = "cmtj/_version.py"
 
 [tool.ruff]


### PR DESCRIPTION
## Summary
- configure setuptools_scm to drop local version identifiers so built distributions satisfy core metadata rules

## Testing
- python -m build

------
https://chatgpt.com/codex/tasks/task_e_68e592c0c27c8320bf745a87b2ee18a5