### PR TITLE
Modify clone command for submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,10 @@ python3 -m pip install git+https://github.com/LemurPwned/cmtj.git
 4. Clone the repository:
 
 ```bash
-git clone https://github.com/LemurPwned/cmtj.git
+git clone --recurse-submodules https://github.com/LemurPwned/cmtj.git
 python3 -m pip install .
 ```
+if your git is older, you may need to use `--recursive` instead of `--recurse-submodules`.
 
 #### Extra dependencies
 


### PR DESCRIPTION
Updated git clone command to include submodules option and added note for older git versions.

## Summary by Sourcery

Documentation:
- Update README clone instructions to use git clone with submodules and note the alternate flag for older git versions.